### PR TITLE
solved the compatibility issue between isort and black

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,16 +148,13 @@ setup.py
 pipenv install isort black --dev
 ```
 
+**NOTICE:** black and isort may have conflits, since they both enforce styles in the code (https://pycqa.github.io/isort/docs/configuration/black_compatibility.html). To ensure isort follows the same style as black, add a line in the configuration file as showed below:
+
 `pyproject.toml`
 
 ```toml
 [tool.isort]
-line_length = 120
-multi_line_output = 3
-include_trailing_comma = true
-force_grid_wrap = 0
-use_parentheses = true
-honor_noqa = true
+profile = "black"
 ```
 
 ```shell

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,7 @@
 ### CODE FORMATTING
 
 [tool.isort]
-line_length = 120
-multi_line_output = 3
-include_trailing_comma = true
-force_grid_wrap = 0
-use_parentheses = true
-honor_noqa = true
+profile = "black"
 
 ### CODE STYLE ENFORCEMENT
 


### PR DESCRIPTION
`isort` one-line configuration compliant with `black` solved the imports style issue (inline vs block sub-imports: causing a validation failure during pre-commit).